### PR TITLE
[COOK-1098] Added Amazon Linux platform support.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,6 @@ description       "Installs C compiler / build tools"
 version           "1.0.0"
 recipe            "build-essential", "Installs C compiler and build tools on Linux"
 
-%w{ fedora redhat centos ubuntu debian }.each do |os|
+%w{ fedora redhat centos ubuntu debian amazon}.each do |os|
   supports os
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ when "ubuntu","debian"
       action :install
     end
   end
-when "centos","redhat","fedora"
+when "centos","redhat","fedora","amazon"
   %w{gcc gcc-c++ kernel-devel make}.each do |pkg|
     package pkg do
       action :install


### PR DESCRIPTION
Case statement in the default recipe captures CentOS, RedHat, and Fedora - but not it's descendant Amazon Linux.
