### PR TITLE
COOK-1149 add support for OSX to build-essential

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: build-essential
+# Attributes:: default
+#
+# Copyright 2008-2012, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case platform
+when "mac_os_x"
+  case
+  when Chef::VersionConstraint.new("~> 10.7.0").include?(platform_version)
+    default['build_essential']['osx']['gcc_installer_url'] = "https://github.com/downloads/kennethreitz/osx-gcc-installer/GCC-10.7-v2.pkg"
+    default['build_essential']['osx']['gcc_installer_checksum'] = "df36aa87606feb99d0db9ac9a492819e"
+  when Chef::VersionConstraint.new("~> 10.6.0").include?(platform_version)
+    default['build_essential']['osx']['gcc_installer_url'] = "https://github.com/downloads/kennethreitz/osx-gcc-installer/GCC-10.6.pkg"
+    default['build_essential']['osx']['gcc_installer_checksum'] = "d1db5bab6a3f6b9f3b5577a130baeefa"
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,10 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs C compiler / build tools"
 version           "1.0.0"
-recipe            "build-essential", "Installs C compiler and build tools on Linux"
+recipe            "build-essential", "Installs packages required for compiling C software from source."
 
-%w{ fedora redhat centos ubuntu debian amazon}.each do |os|
+%w{ fedora redhat centos ubuntu debian amazon }.each do |os|
   supports os
 end
+
+supports "mac_os_x", ">= 10.6.0"


### PR DESCRIPTION
The build-essential cookbook is described to:
"Installs C compiler and build tools on Linux"

OSX does not come with a built in way to compile C software from source. Since the build-essential cookbook's job is to install the requirements for compiling C software from source, we should expand build-essential to also work on OSX and change it's description to:
"Installs packages required for compiling C software from source."
