### PR TITLE
[COOK-1677] build-essential cookbook support for OpenSuse and SLES

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ description       "Installs C compiler / build tools"
 version           "1.1.2"
 recipe            "build-essential", "Installs packages required for compiling C software from source."
 
-%w{ fedora redhat centos ubuntu debian amazon }.each do |os|
+%w{ fedora redhat centos ubuntu debian amazon suse }.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,6 +42,8 @@ when "linux"
       %w{build-essential binutils-doc}
     when "rhel", "fedora"
       %w{gcc gcc-c++ kernel-devel make}
+    when "suse"
+      %w{gcc gcc-c++ kernel-default-devel make m4}  # in SLES there is no kernel-devel
     end
 
   packages.each do |pkg|


### PR DESCRIPTION
Add support for Suse ditros, as this cookbook is a dependency of other ones needed to use on OpenSuse/SLES.

I signed the corporate CLA (The App Business), but I don't know if it has been reviewed yet.
