### PR TITLE
[COOK-1690] Compilation failure on undefined method each for nil:NilClass

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,18 +44,22 @@ when "linux"
       %w{gcc gcc-c++ kernel-devel make}
     end
 
-  packages.each do |pkg|
-    r = package pkg do
-      action ( compiletime ? :nothing : :install )
+  if packages
+    packages.each do |pkg|
+      r = package pkg do
+        action ( compiletime ? :nothing : :install )
+      end
+      r.run_action(:install) if compiletime
     end
-    r.run_action(:install) if compiletime
   end
 
-  %w{autoconf flex bison}.each do |pkg|
-    r = package pkg do
-      action ( compiletime ? :nothing : :install )
+  if %w{autoconf flex bison}
+    %w{autoconf flex bison}.each do |pkg|
+      r = package pkg do
+        action ( compiletime ? :nothing : :install )
+      end
+      r.run_action(:install) if compiletime
     end
-    r.run_action(:install) if compiletime
   end
 when "darwin"
   result = Chef::ShellOut.new("pkgutil --pkgs").run_command


### PR DESCRIPTION
Resolved issue with failure of empty each.

http://tickets.opscode.com/browse/COOK-1690

`````` ================================================================================
Recipe Compile Error in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/build-essential/recipes/default.rb
================================================================================

NoMethodError
-------------
undefined method `each' for nil:NilClass

Cookbook Trace:
---------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/build-essential/recipes/default.rb:47:in `from_file'

Relevant File Content:
----------------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/build-essential/recipes/default.rb:

1: #
2: # Cookbook Name:: build-essential
3: # Recipe:: default
4: #
5: # Copyright 2008-2009, Opscode, Inc.
6: #
7: # Licensed under the Apache License, Version 2.0 (the "License");
8: # you may not use this file except in compliance with the License.
9: # You may obtain a copy of the License at

[Fri, 21 Sep 2012 06:03:37 -0700] ERROR: Running exception handlers
[Fri, 21 Sep 2012 06:03:37 -0700] ERROR: Exception handlers complete
[Fri, 21 Sep 2012 06:03:37 -0700] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[Fri, 21 Sep 2012 06:03:37 -0700] FATAL: NoMethodError: undefined method `each' for nil:NilClass```
``````
