### PR TITLE
[COOK-3318] Use Mixlib::ShellOut instead of Chef::ShellOut

### DIFF
--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -17,9 +17,8 @@
 # limitations under the License.
 #
 
-require 'chef/shell_out'
 
-result = Chef::ShellOut.new("pkgutil --pkgs").run_command
+result = Mixlib::ShellOut.new("pkgutil --pkgs").run_command
 osx_gcc_installer_installed = result.stdout.split("\n").include?("com.apple.pkg.gcc4.2Leo")
 developer_tools_cli_installed = result.stdout.split("\n").include?("com.apple.pkg.DeveloperToolsCLI")
 pkg_filename = ::File.basename(node['build_essential']['osx']['gcc_installer_url'])


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3318

Update recipes/default/mac_os_x to use Mixlib::ShellOut over the deprecated Chef::ShellOut
