### PR TITLE
Traps CookbookNotFound exception in default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,8 @@
 
 begin
   include_recipe "build-essential::#{node['platform_family']}"
+rescue Chef::Exceptions::CookbookNotFound
+  Chef::Log.warn "Chef cannot find the build-essential cookbook while running build-essential::default"
 rescue Chef::Exceptions::RecipeNotFound
   Chef::Log.warn "A build-essential recipe does not exist for the platform_family: #{node['platform_family']}"
 end


### PR DESCRIPTION
This pull request avoid a very strange error that sometimes comes when running `ChefSpec` tests with `Berkshelf` on recipes that indirectly depend on `build-essential`. It is unclear what causes the problem. It is not cookbook paths as the problem is specific to `build-essential` and not any other dependent cookbooks. The mere notion that the cookbook where a recipe is running cannot be found is perplexing but there seems to be no harm in trapping the exception and issuing a warning.

```
Chef::Exceptions::CookbookNotFound
----------------------------------
Cookbook build-essential:: not found. If you're loading build-essential:: from another cookbook, make sure you configure the dependency in your metadata

Cookbook Trace:
---------------
  /Users/sim/dev/spx/chef/cookbooks/spxinternal/vendor/cookbooks/build-essential/recipes/default.rb:21:in `from_file'
  /Users/sim/dev/spx/chef/cookbooks/spxinternal/vendor/cookbooks/rvm/recipes/default.rb:11:in `from_file'
  /Users/sim/dev/spx/chef/cookbooks/spxinternal/vendor/cookbooks/spxinternal/recipes/default.rb:11:in `from_file'

Relevant File Content:
----------------------
/Users/sim/dev/spx/chef/cookbooks/spxinternal/vendor/cookbooks/build-essential/recipes/default.rb:

 14:  # distributed under the License is distributed on an "AS IS" BASIS,
 15:  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 16:  # See the License for the specific language governing permissions and
 17:  # limitations under the License.
 18:  #
 19:
 20:  begin
 21>>   include_recipe "build-essential::#{node['platform_family']}"
 22:  rescue Chef::Exceptions::RecipeNotFound
 23:    Chef::Log.warn "A build-essential recipe does not exist for the platform_family: #{node['platform_family']}"
 24:  end
 25:

  example at ./spec/default_spec.rb:19 (FAILED - 1)

Failures:

  1) spxinternal::default
     Failure/Error: let (:chef_run) { ChefSpec::ChefRunner.new(cookbook_path: '/Users/sim/dev/spx/chef/cookbooks/spxinternal/vendor/cookbooks').converge 'spxinternal::default' }
     Chef::Exceptions::CookbookNotFound:
       Cookbook build-essential:: not found. If you're loading build-essential:: from another cookbook, make sure you configure the dependency in your metadata
     # ./vendor/cookbooks/build-essential/recipes/default.rb:21:in `from_file'
     # ./vendor/cookbooks/rvm/recipes/default.rb:11:in `from_file'
     # ./vendor/cookbooks/spxinternal/recipes/default.rb:11:in `from_file'
     # ./spec/default_spec.rb:17:in `block (2 levels) in <top (required)>'
     # ./spec/default_spec.rb:19:in `block (2 levels) in <top (required)>'
```
