### PR TITLE
[COOK-3413] kernel-devel version attribute is set properly for RHEL

### DIFF
--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -37,7 +37,7 @@ pkgs.flatten.each do |pkg|
 
   r = package pkg do
     action( node['build_essential']['compiletime'] ? :nothing : :install )
-    # TODO: Fix http://tickets.opscode.com/browse/CHEF-4439
+    # TODO: Fix http://tickets.opscode.com/browse/CHEF-4437
     # Chef::Platform os_version attr for RHEL include ARCH which needs to be stripped of for the yum installation to work
     # version( node['os_version'] ) if pkg == 'kernel-devel'
     if pkg == 'kernel-devel'


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3413

The code is safe in that it will not break when the arch attribute is removed from os_version in Chef::Platform
