### PR TITLE
[COOK-3318] - Use Chef::Mixin::ShellOut

### DIFF
--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -17,9 +17,10 @@
 # limitations under the License.
 #
 
-require 'chef/shell_out'
+require 'chef/mixin/shell_out'
+Chef::Recipe.send(:include, Chef::Mixin::ShellOut)
 
-result = Chef::ShellOut.new("pkgutil --pkgs").run_command
+result = shell_out("pkgutil --pkgs").run_command
 osx_gcc_installer_installed = result.stdout.split("\n").include?("com.apple.pkg.gcc4.2Leo")
 developer_tools_cli_installed = result.stdout.split("\n").include?("com.apple.pkg.DeveloperToolsCLI")
 pkg_filename = ::File.basename(node['build_essential']['osx']['gcc_installer_url'])


### PR DESCRIPTION
Instead of using Mixlib::ShellOut, use the mixin, per discussion in 8/12 code review.
