### PR TITLE
Add integration test coverage for default suite

### DIFF
--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,22 @@
+require 'serverspec'
+require 'pathname'
+
+include Serverspec::Helper::Exec
+
+# Ensure GCC exists
+describe command('gcc --version') do
+  it { should return_exit_status 0 }
+end
+
+# On FreeBSD `make` is actually BSD make
+gmake_bin = if RUBY_PLATFORM =~ /freebsd/
+              'gmake'
+            else
+              'make'
+            end
+
+# Ensure GNU Make exists
+describe command("#{gmake_bin} --version") do
+  it { should return_exit_status 0 }
+  it { should return_stdout /GNU/ }
+end


### PR DESCRIPTION
Nothing fancy, this serverspec test verifies:
- GCC is installed and available.
- The GNU flavor of Make is installed and available.

I've verified this test passes against all platforms listed in the current `.kitchen.yml`
