### PR TITLE
fix rhel

### DIFF
--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -26,9 +26,11 @@ potentially_at_compile_time do
   package 'kernel-devel'
   package 'make'
   package 'm4'
+end
 
-  # Ensure GCC 4 is available on older pre-6 EL
-  if node['platform_version'].to_i < 6
+# Ensure GCC 4 is available on older pre-6 EL
+if node['platform_version'].to_i < 6
+  potentially_at_compile_time do
     package 'gcc44'
     package 'gcc44-c++'
   end


### PR DESCRIPTION
node object is not available inside the block, the code that
handles the block assumes every 'method-missing' is a resource
and node isn't a resource.
