### PR TITLE
fix rhel attempt #2

### DIFF
--- a/libraries/timing.rb
+++ b/libraries/timing.rb
@@ -106,12 +106,15 @@ EOH
 
       def method_missing(m, *args, &block)
         resource = @recipe.send(m, *args, &block)
-        actions  = Array(resource.action)
-        resource.action(:nothing)
+        if resource.is_a?(Chef::Resource)
+          actions  = Array(resource.action)
+          resource.action(:nothing)
 
-        actions.each do |action|
-          resource.run_action(action)
+          actions.each do |action|
+            resource.run_action(action)
+          end
         end
+        resource
       end
     end
   end


### PR DESCRIPTION
if what we get back is a Chef::Resource then wire it up, otherwise
just return the thing we get back.
