### PR TITLE
OpenCSW has removed gcc3* from the stable repo

### DIFF
--- a/recipes/_solaris2.rb
+++ b/recipes/_solaris2.rb
@@ -26,8 +26,6 @@ potentially_at_compile_time do
   package 'gcc4core'
   package 'gcc4g++'
   package 'gcc4objc'
-  package 'gcc3core'
-  package 'gcc3g++'
   package 'ggrep'
   package 'gmake'
   package 'gtar'


### PR DESCRIPTION
http://www.opencsw.org/get-it/packages/
