### PR TITLE
[COOK-4441] doc update for supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ v2.0.0 (2014-03-13)
 - OSX no longer downloads OSX GCC and uses XCode CLI tools instead
 - `build_essential` -> `build-essential` in node attributes
 - `compiletime` -> `compile_time` in node attributes
+- Cookbook version 2.x no longer supports Chef 10.x
 
 v1.4.4 (2014-02-27)
 -------------------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ extensions.
 
 Requirements
 ------------
-Chef 0.10.10+ and Ohai 0.6.12+ are required. For the latest list of supported
+Chef 11+ and Ohai 6.14+ are required. For the latest list of supported
 platforms, please see the `metadata.rb`.
 
 **Note for OmniOS**: Currently, OmniOS's Ruby package is built with


### PR DESCRIPTION
In commit b30b54156c36c554b56d4cfaa079f39c5042f715 a library was added
that will not work on Chef 10. This updates the user about what versions
of Chef are supported.

[ci skip]
