### PR TITLE
Adding support for ChefSpec platform family

### DIFF
--- a/recipes/_chefspec.rb
+++ b/recipes/_chefspec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: build-essential
+# Recipe:: _chefspec
+#
+# Copyright 2008-2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Chef::Log.debug "Loaded `build-essential` in Test Environment (ChefSpec)"


### PR DESCRIPTION
When running tests with ChefSpec I load the build-essentials recipe and a number of warnings appear stating that the node's platform is not supported. The node is the chefspec generated node from Fauxhai.

The node currently does not have a platform family. It is set to nil with ChefSpec 4.0.1 version. I have proposed a pull request to set the platform_family to `chefspec` for a ChefSpec node. This pull request would support the platform family so that tests do not generate a lot of extraneous error messages.