### PR TITLE
Use `Chef::Resource::RemoteFile` class in providers

### DIFF
--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -131,9 +131,10 @@ class Chef
     # @return [void]
     #
     def download
-      remote_file dmg_cache_path do
-        source dmg_remote_source
-      end
+      remote_file = Resource::RemoteFile.new(dmg_cache_path, run_context)
+      remote_file.source(dmg_remote_source)
+      remote_file.backup(false)
+      remote_file.run_action(:create)
     end
 
     #


### PR DESCRIPTION
The block form of `remote_file` does not work as `dmg_remote_source` is 
not defined on instances of `Chef::Resource::RemoteFile`.

/cc @opscode-cookbooks/release-engineers 
