### PR TITLE
Ensure kernel-devel matches the running kernel

### DIFF
--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -23,10 +23,14 @@ potentially_at_compile_time do
   package 'flex'
   package 'gcc'
   package 'gcc-c++'
-  package 'kernel-devel'
   package 'make'
   package 'm4'
   package 'patch'
+
+  # Ensure kernel-devel is the same as the current kernel version
+  package 'kernel-devel' do
+    version node['kernel']['release'].sub(".#{node['kernel']['machine']}", '')
+  end
 
   # Ensure GCC 4 is available on older pre-6 EL
   if node['platform_version'].to_i < 6

--- a/spec/recipes/rhel_spec.rb
+++ b/spec/recipes/rhel_spec.rb
@@ -12,7 +12,7 @@ describe 'build-essential::_rhel' do
     expect(chef_run).to install_package('flex')
     expect(chef_run).to install_package('gcc')
     expect(chef_run).to install_package('gcc-c++')
-    expect(chef_run).to install_package('kernel-devel')
+    expect(chef_run).to install_package('kernel-devel').with(version: chef_run.node['kernel']['release'].sub(".#{chef_run.node['kernel']['machine']}", ''))
     expect(chef_run).to install_package('make')
     expect(chef_run).to install_package('m4')
     expect(chef_run).to install_package('patch')


### PR DESCRIPTION
Force the version of kernel-devel that is installed to match that of
the running kernel.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>