### PR TITLE
Remove Xcode Tools Markerfile

### DIFF
--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -185,6 +185,8 @@ class Chef
               PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
               # install it
               softwareupdate -i "$PROD" -v
+              # Remove the placeholder to prevent perpetual appearance in the update utility
+              rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
             EOH
             # rubocop:enable Metrics/LineLength
           end


### PR DESCRIPTION
Remove the placeholder to prevent perpetual appearance in the update utility.  I noticed that this continually reappears as a software update, until the file is gone or removed, either manually or by reboot...  Let's just remove it after installation!