### PR TITLE
Release 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ build-essential Cookbook CHANGELOG
 ==================================
 This file is used to list changes made in each version of the build-essential cookbook.
 
+v2.2.4 (2015-10-06)
+-------------------
+* Add patch package on Fedora systems
+* Add additional platforms to Kitchen CI
+* Use Chef standard Rubocop file and resolve several issues
+* Update contributing and testing docs
+* Update Gemfile with the latest testing and development deps
+* Add maintainers.md and maintainers.toml files
+* Add chefignore file to limit the files uploaded to the Chef server
+* Add source_url and issues_url metadata for Supermarket
+
 v2.2.3 (2015-04-15)
 -------------------
 * Don’t install omnibus-build-essential on Solaris 10 - We decided it’s easier to use the old GCC that ships with Solaris 10.

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs C compiler / build tools'
-version           '2.2.3'
+version           '2.2.4'
 recipe            'build-essential', 'Installs packages required for compiling C software from source.'
 
 supports 'amazon'


### PR DESCRIPTION
This is mostly to add patch to fedora which is breaking cookbooks like
XML on fedora

https://github.com/chef-cookbooks/build-essential/compare/662847e53cc1f90d193ad7a7e6f653953858d804...master