### PR TITLE
Add OSX 10.11 to the list of OSX providers list

### DIFF
--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -32,7 +32,7 @@ class Chef
       @provider = case node['platform_version'].to_f
                   when 10.7, 10.8
                     Provider::XcodeCommandLineToolsFromDmg
-                  when 10.9, 10.10
+                  when 10.9, 10.10, 10.11
                     Provider::XcodeCommandLineToolsFromSoftwareUpdate
                   else
                     Chef::Log.warn <<-EOH


### PR DESCRIPTION
It's possible to install CLI from Software Update on OSX 10.11 using
this cookbook (tested on 10.11.1 [BuildVersion 15B42]). Let's consider
10.11 officially supported platform.

Signed-off-by: Lesya Novaselskaya <shams.for.real@gmail.com>