### PR TITLE
Update build essential to support omnibus-toolchain

### DIFF
--- a/recipes/_debian.rb
+++ b/recipes/_debian.rb
@@ -25,4 +25,6 @@ potentially_at_compile_time do
   package 'flex'
   package 'gettext'
   package 'ncurses-dev'
+  package 'libacl1-dev'
+  package 'libcap-dev'
 end

--- a/recipes/_fedora.rb
+++ b/recipes/_fedora.rb
@@ -29,4 +29,8 @@ potentially_at_compile_time do
   package 'm4'
   package 'ncurses-devel'
   package 'patch'
+  package 'libattr-devel'
+  package 'libcap-devel'
+  package 'rpmdevtools'
+  package 'git'
 end

--- a/recipes/_fedora.rb
+++ b/recipes/_fedora.rb
@@ -28,9 +28,7 @@ potentially_at_compile_time do
   package 'make'
   package 'm4'
   package 'ncurses-devel'
-  package 'patch'
   package 'libattr-devel'
   package 'libcap-devel'
   package 'rpmdevtools'
-  package 'git'
 end

--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -26,11 +26,9 @@ potentially_at_compile_time do
   package 'kernel-devel'
   package 'make'
   package 'm4'
-  package 'patch'
   package 'libattr-devel'
   package 'libcap-devel'
   package 'rpmdevtools'
-  package 'git'
   package 'gettext'
 
   # Ensure GCC 4 is available on older pre-6 EL

--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -27,6 +27,11 @@ potentially_at_compile_time do
   package 'make'
   package 'm4'
   package 'patch'
+  package 'libattr-devel'
+  package 'libcap-devel'
+  package 'rpmdevtools'
+  package 'git'
+  package 'gettext'
 
   # Ensure GCC 4 is available on older pre-6 EL
   if node['platform_version'].to_i < 6

--- a/recipes/_suse.rb
+++ b/recipes/_suse.rb
@@ -26,8 +26,6 @@ potentially_at_compile_time do
   package 'kernel-default-devel'
   package 'make'
   package 'm4'
-  package 'patch'
-  package 'git'
   package 'gettext-tools'
   package 'libacl-devel'
   package 'libcap-devel'

--- a/recipes/_suse.rb
+++ b/recipes/_suse.rb
@@ -26,4 +26,8 @@ potentially_at_compile_time do
   package 'kernel-default-devel'
   package 'make'
   package 'm4'
+  package 'git'
+  package 'gettext'
+  package 'libacl1'
+  package 'libcap'
 end

--- a/recipes/_suse.rb
+++ b/recipes/_suse.rb
@@ -26,8 +26,10 @@ potentially_at_compile_time do
   package 'kernel-default-devel'
   package 'make'
   package 'm4'
+  package 'patch'
   package 'git'
-  package 'gettext'
-  package 'libacl1'
-  package 'libcap'
+  package 'gettext-tools'
+  package 'libacl-devel'
+  package 'libcap-devel'
+  package 'libattr-devel'
 end


### PR DESCRIPTION
This adds support to build fakeroot ( chef/omnibus-software#522 ) as well as ensuring omnibus-toolchain will build on Linux platforms running a RHEL, SUSE, or DEBIAN family distrobution.