### PR TITLE
Fix Mac OS X Version Determination

### DIFF
--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -34,7 +34,7 @@ class Chef
       @provider = case [major, minor].join('.')
                   when '10.7', '10.8'
                     Provider::XcodeCommandLineToolsFromDmg
-                  when '10.9', '10.10'
+                  when '10.9', '10.10', '10.11'
                     Provider::XcodeCommandLineToolsFromSoftwareUpdate
                   else
                     Chef::Log.warn <<-EOH

--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -29,10 +29,12 @@ class Chef
     def initialize(name, run_context = nil)
       super
 
-      @provider = case node['platform_version'].to_f
-                  when 10.7, 10.8
+      # => Break down SemVer
+      major, minor, _patch = node['platform_version'].split('.').map { |v| String(v) }
+      @provider = case [major, minor].join('.')
+                  when '10.7', '10.8'
                     Provider::XcodeCommandLineToolsFromDmg
-                  when 10.9, 10.10
+                  when '10.9', '10.10'
                     Provider::XcodeCommandLineToolsFromSoftwareUpdate
                   else
                     Chef::Log.warn <<-EOH


### PR DESCRIPTION
`to_f` will strip trailing zeros, so 10.10 will result in 10.1