### PR TITLE
Use berkshelf for chefspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'chefspec'
+require 'chefspec/berkshelf'
+
 ChefSpec::Coverage.start!
 
 RSpec.configure do |config|


### PR DESCRIPTION
This will correctly set the cookbook_path so that it
does not rely on things on the dev machine.