### PR TITLE
Backwards compatibility: protect "provides" method with if responds_to?

### DIFF
--- a/providers/msys_archive.rb
+++ b/providers/msys_archive.rb
@@ -19,7 +19,7 @@
 
 use_inline_resources
 
-provides :msys_archive
+provides :msys_archive if Chef::Provider.respond_to?(:provides)
 
 action :unpack do
   directory msys_dir do


### PR DESCRIPTION
Fixes https://github.com/chef-cookbooks/build-essential/issues/84 for those of us still using Chef 11