### PR TITLE
Update gcc to version 4.9 on freebsd 9

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -21,6 +21,24 @@ platforms:
     run_command: /usr/lib/systemd/systemd
     provision_command:
       - /bin/yum install -y initscripts net-tools wget
+- name: debian-7
+  driver:
+    image: debian:7
+    platform: debian
+    disable_upstart: false
+    run_command: /sbin/init
+    provision_command:
+      - /usr/bin/apt-get update
+      - /usr/bin/apt-get install apt-transport-https net-tools -y
+- name: debian-8
+  driver:
+    image: debian:8
+    platform: debian
+    disable_upstart: false
+    run_command: /sbin/init
+    provision_command:
+      - /usr/bin/apt-get update
+      - /usr/bin/apt-get install apt-transport-https net-tools -y
 - name: ubuntu-12.04
   driver:
     image: ubuntu-upstart:12.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,13 @@ platforms:
     run_list: yum::dnf_yum_compat
   - name: fedora-23
     run_list: yum::dnf_yum_compat
+  - name: freebsd-9.3
+    run_list:
+      - freebsd::portsnap
+      - freebsd::pkgng
+  - name: freebsd-10.2
+    run_list:
+      - freebsd::portsnap
   - name: ubuntu-12.04
     run_list: apt::default
   - name: ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
+  - INSTANCE=default-debian-7
+  - INSTANCE=default-debian-8
   - INSTANCE=default-ubuntu-1404-chef11
 
 # Don't `bundle install`

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ end
 group :kitchen_common do
   gem 'test-kitchen', '~> 1.5'
   gem 'winrm-transport'
+  gem 'winrm-fs'
 end
 
 group :kitchen_vagrant do

--- a/recipes/_freebsd.rb
+++ b/recipes/_freebsd.rb
@@ -22,4 +22,6 @@ potentially_at_compile_time do
   package 'devel/autoconf'
   package 'devel/m4'
   package 'devel/gettext'
+  # Only install gcc on freebsd 9.x - 10 uses clang
+  package 'lang/gcc49' if node['platform_version'].to_i <= 9
 end


### PR DESCRIPTION
Ensures we have at least gcc 4.9 on FreeBSD 9 (previously had 4.1)