### PR TITLE
Add Debian platforms for Travis test matrix.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -21,6 +21,10 @@ platforms:
     run_command: /usr/lib/systemd/systemd
     provision_command:
       - /bin/yum install -y initscripts net-tools wget
+- name: debian-7.9
+  run_list: apt::default
+- name: debian-8.2
+  run_list: apt::default
 - name: ubuntu-12.04
   driver:
     image: ubuntu-upstart:12.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   matrix:
   - INSTANCE=default-ubuntu-1204
   - INSTANCE=default-ubuntu-1404
+  - INSTANCE=debian-7.9
+  - INSTANCE=debian-8.2
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
   - INSTANCE=default-ubuntu-1404-chef11


### PR DESCRIPTION
This adds the missing Debian platforms to the test matrix. This will help to ensure changes which attempt to reference specific packages or versions work on all supported Debian variants before the change is landed. 