### PR TITLE
Revert PR #73 due to unexpected fallout

### DIFF
--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -23,17 +23,11 @@ potentially_at_compile_time do
   package 'flex'
   package 'gcc'
   package 'gcc-c++'
+  package 'kernel-devel'
   package 'make'
   package 'm4'
   package 'patch'
   package 'gettext-devel'
-
-  # Ensure kernel-devel is the same as the current kernel version
-  # Don't specify the version when on docker as this fails travis
-  package 'kernel-devel' do
-    action :install
-    version node['kernel']['release'].sub(".#{node['kernel']['machine']}", '') unless node['virtualization']['systems'] && node['virtualization']['systems']['docker'] && node['virtualization']['systems']['docker'] == 'guest'
-  end
 
   # Ensure GCC 4 is available on older pre-6 EL
   if node['platform_version'].to_i < 6

--- a/spec/recipes/rhel_spec.rb
+++ b/spec/recipes/rhel_spec.rb
@@ -13,7 +13,7 @@ describe 'build-essential::_rhel' do
     expect(chef_run).to install_package('flex')
     expect(chef_run).to install_package('gcc')
     expect(chef_run).to install_package('gcc-c++')
-    expect(chef_run).to install_package('kernel-devel').with(version: '2.6.32-573.el6')
+    expect(chef_run).to install_package('kernel-devel')
     expect(chef_run).to install_package('make')
     expect(chef_run).to install_package('m4')
     expect(chef_run).to install_package('patch')


### PR DESCRIPTION
This broke systems running kernels that were no longer available in the
package repo and also broke Amazon.  It also blew up anyone running
chefspecs on a system with build-essential since we don't mock out
node['virtualization'] in fauxhai.  We need to rethink this before doing
it again.