### PR TITLE
[ISSUE-107] - Use now cookbook so that seven_zip can be included usin…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,6 +23,7 @@ supports 'ubuntu'
 supports 'windows'
 supports 'zlinux'
 
+depends 'now'
 depends 'seven_zip'
 
 source_url 'https://github.com/chef-cookbooks/build-essential' if respond_to?(:source_url)

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -19,7 +19,7 @@
 require 'ostruct'
 
 node.default['seven_zip']['syspath'] = true
-include_recipe 'seven_zip::default'
+include_recipe_now 'seven_zip::default'
 
 [
   msys_p('http://downloads.sourceforge.net/mingw/msysCORE-1.0.17-1-msys-1.0.17-bin.tar.lzma',


### PR DESCRIPTION
Allows seven zip to be installed during compile time on windows when compile_time is true by using the include_recipe_now resource from the now cookbook.
