### PR TITLE
Update for msys2 windows compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Installs packages required for compiling C software from source. Use this cookbo
 Attribute                                    |             Default             | Description
 -------------------------------------------- | :-----------------------------: | --------------------------------------------------------------
 `node['build-essential']['compile_time']`    |             `false`             | Execute resources at compile time
-`node['build-essential']['mingw32']['path']` | `#{ENV['SYSTEMDRIVE']\\mingw32` | Destination for mingw 32-bit compiler toolchain (Windows only)
-`node['build-essential']['mingw64']['path']` | `#{ENV['SYSTEMDRIVE']\\mingw64` | Destination for mingw 64-bit compiler toolchain (Windows only)
+`node['build-essential']['msys2']['path']`   | `#{ENV['SYSTEMDRIVE']\\msys2`   | Destination for msys2 build tool chain (Windows only)
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,4 @@
 #
 
 default['build-essential']['compile_time'] = false
-default['build-essential']['mingw32']['path'] = "#{ENV['SYSTEMDRIVE']}\\mingw32"
-default['build-essential']['mingw64']['path'] = "#{ENV['SYSTEMDRIVE']}\\mingw64"
+default['build-essential']['msys2']['path'] = "#{ENV['SYSTEMDRIVE']}\\msys2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,7 +26,7 @@ supports 'windows'
 supports 'zlinux'
 
 depends 'seven_zip'
-depends 'mingw'
+depends 'mingw', '>= 1.1'
 depends 'compat_resource', '>= 12.10'
 
 source_url 'https://github.com/chef-cookbooks/build-essential'

--- a/spec/recipes/windows_spec.rb
+++ b/spec/recipes/windows_spec.rb
@@ -1,25 +1,23 @@
 require 'spec_helper'
 
 describe 'build-essential::default' do
-  let(:path32) { 'C:\\mingw32' }
-  let(:path64) { 'C:\\mingw64' }
+  let(:path) { 'C:\\msys2' }
   let(:chef_run) do
     ChefSpec::ServerRunner.new(platform: 'windows', version: '2012R2',
                                step_into: ['build_essential']) do |node|
-      node.set['build-essential']['mingw32']['path'] = path32
-      node.set['build-essential']['mingw64']['path'] = path64
+      node.set['build-essential']['msys2']['path'] = path
     end.converge(described_recipe)
   end
 
   it 'creates the correct toolchain dir structure' do
-    expect(chef_run).to create_directory(path32).with(recursive: true)
-    expect(chef_run).to create_directory(path64).with(recursive: true)
+    expect(chef_run).to create_directory(path).with(recursive: true)
   end
 
-  it 'copies tar to the right place' do
-    expect(chef_run).to create_remote_file("#{path32}\\bin\\tar.exe")
-      .with(source: 'file:///C:/mingw32/bin/bsdtar.exe')
-    expect(chef_run).to create_remote_file("#{path64}\\bin\\tar.exe")
-      .with(source: 'file:///C:/mingw64/bin/bsdtar.exe')
+  it 'creates binstub for tar' do
+    expect(chef_run).to create_file("#{path}\\bin\\tar.bat")
+  end
+
+  it 'creates binstub for patch' do
+    expect(chef_run).to create_file("#{path}\\bin\\patch.bat")
   end
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -4,7 +4,7 @@ require 'pathname'
 compilers = if (os[:family] == 'freebsd') && (os[:release].to_i == 10)
               %w(cc c++)
             elsif os[:family] == 'windows'
-              %w(gcc g++)
+              %w(C:\\msys2\\mingw32\\bin\\gcc C:\\msys2\\mingw32\\bin\\g++)
             else
               %w(gcc g++ cc c++)
             end
@@ -12,12 +12,15 @@ compilers = if (os[:family] == 'freebsd') && (os[:release].to_i == 10)
 compilers.each do |compiler|
   describe command("#{compiler} --version") do
     its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
   end
 end
 
 # On FreeBSD `make` is actually BSD make
 gmake_bin = if os[:family] == 'freebsd'
               'gmake'
+            elsif os[:family] == 'windows'
+              'C:\\msys2\\usr\\bin\\make'
             else
               'make'
             end


### PR DESCRIPTION
### Description

Allows windows to use the msys2 framework and install a recent msys2 base mingw-w64 compiler.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


