### PR TITLE
Allow to install untrusted packages on OSX

### DIFF
--- a/libraries/xcode_command_line_tools.rb
+++ b/libraries/xcode_command_line_tools.rb
@@ -154,7 +154,9 @@ class Chef
     # @return [void]
     #
     def install
-      execute %|installer -package "$(find '#{mount_path}' -name *.mpkg)" -target "/"|
+      # The "-allowUntrusted" flag has been added to the installer command to accommodate
+      # for now-expired certificates used to sign the downloaded command line tools.
+      execute %|installer -allowUntrusted -package "$(find '#{mount_path}' -name *.mpkg)" -target "/"|
     end
 
     #


### PR DESCRIPTION
### Description

Fixes failing converge on OSX 10.7

### Issues Resolved

#117 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
N/A Makes it work at all
- [ ] New functionality has been documented in the README if applicable
N/A
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD