### PR TITLE
Solaris 11 needs both make and gnu make

### DIFF
--- a/resources/build_essential.rb
+++ b/resources/build_essential.rb
@@ -71,6 +71,7 @@ action :install do
       package 'gnu-make'
       package 'gnu-patch'
       package 'gnu-tar'
+      package 'make'
       package 'pkg-config'
       package 'ucb'
     end

--- a/spec/recipes/solaris2_spec.rb
+++ b/spec/recipes/solaris2_spec.rb
@@ -18,6 +18,7 @@ describe 'build-essential::default' do
     expect(chef_run).to install_package('gnu-make')
     expect(chef_run).to install_package('gnu-patch')
     expect(chef_run).to install_package('gnu-tar')
+    expect(chef_run).to install_package('make')
     expect(chef_run).to install_package('pkg-config')
     expect(chef_run).to install_package('ucb')
   end


### PR DESCRIPTION
### Description

We install GNU `make` but not Oracle `make` on Solaris 11, which is needed for downstream packaging.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


