### PR TITLE
Install gcc 4.8 on SUSE < 12

### DIFF
--- a/resources/build_essential.rb
+++ b/resources/build_essential.rb
@@ -84,6 +84,7 @@ action :install do
     package 'pkg-config'
   when 'suse'
     package %w( autoconf bison flex gcc gcc-c++ kernel-default-devel make m4 )
+    package %w( gcc48 gcc48-c++ ) if node['platform_version'].to_i < 12
   when 'windows'
     include_recipe 'build-essential::_windows'
   else

--- a/spec/recipes/suse_spec.rb
+++ b/spec/recipes/suse_spec.rb
@@ -9,4 +9,15 @@ describe 'build-essential::default' do
   it 'installs the correct packages' do
     expect(chef_run).to install_package(['autoconf', 'bison', 'flex', 'gcc', 'gcc-c++', 'kernel-default-devel', 'make', 'm4'])
   end
+
+  context 'on suse < 12' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'suse', version: '11.4',
+                                 step_into: ['build_essential']).converge(described_recipe)
+    end
+
+    it 'installs more packages' do
+      expect(chef_run).to install_package(['gcc48', 'gcc48-c++'])
+    end
+  end
 end


### PR DESCRIPTION
### Description

This allows builds of Ruby on SLES/SUSE 11.4 to succeed.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Signed-off-by: Scott Hain <shain@chef.io>