### PR TITLE
Confirmed that softwareupdate doesn't have a -v option anymore.

### DIFF
--- a/resources/xcode_command_line_tools.rb
+++ b/resources/xcode_command_line_tools.rb
@@ -34,7 +34,7 @@ action :install do
           # find the CLI Tools update
           PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
           # install it
-          softwareupdate -i "$PROD" -v
+          softwareupdate -i "$PROD" --verbose
           # Remove the placeholder to prevent perpetual appearance in the update utility
           rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
         EOH


### PR DESCRIPTION
### Description

Fix issue with softwareupdate no longer having the -v option.

### Issues Resolved

Issue #125 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jennifer Davis <iennae@gmail.com>